### PR TITLE
Use LBM instead of ABM to restore sign text

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -936,11 +936,12 @@ signs_lib.register_fence_with_sign("default:fence_wood", "signs:sign_post")
 
 -- restore signs' text after /clearobjects and the like
 
-minetest.register_abm({
+minetest.register_lbm({
 	nodenames = signs_lib.sign_node_list,
-	interval = 15,
-	chance = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider)
+	name = "signs_lib:restore_sign_text",
+	label = "Restore sign text",
+	run_at_every_load = true,
+	action = function(pos, node)
 		signs_lib.update_sign(pos)
 	end
 })


### PR DESCRIPTION
Seeing as how the point of this part is to restore the sign text after a /clearobjects or similar, it doesn't make a whole lot of sense to have it process every sign in the area every 15 seconds. With it converted to an LBM, it still works (I did a /clearobjects and the text did reappear next time I got near the signs), and the profiler no longer shows it as being responsible for 80% of the lag when I'm standing near a lot of signs.