### PR TITLE
Add cornernote's 'craft_guide' as optional dependency:

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -2,3 +2,4 @@ default
 intllib?
 screwdriver?
 keyword_interact?
+craft_guide?


### PR DESCRIPTION
For compatibility with [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/).